### PR TITLE
Pass day to event handlers

### DIFF
--- a/src/ReactEventCalendar.js
+++ b/src/ReactEventCalendar.js
@@ -199,9 +199,9 @@ class EventCalendar extends React.Component {
             <div className={eventClasses}
                 key={UID}
                 ref={(component) => this._eventTargets[UID] = component}
-                onClick={this.props.onEventClick.bind(null, this._eventTargets[UID], eventData)}
-                onMouseOver={this.props.onEventMouseOver.bind(null, this._eventTargets[UID], eventData)}
-                onMouseOut={this.props.onEventMouseOut.bind(null, this._eventTargets[UID], eventData)}>
+                onClick={this.props.onEventClick.bind(null, this._eventTargets[UID], eventData, day)}
+                onMouseOver={this.props.onEventMouseOver.bind(null, this._eventTargets[UID], eventData, day)}
+                onMouseOut={this.props.onEventMouseOut.bind(null, this._eventTargets[UID], eventData, day)}>
                 <div className="event-title">
                     {title}    
                 </div>


### PR DESCRIPTION
This allows event click/moueover/mouseout to behave differently depending on which day of a multi-day event was clicked.

See #3
