### PR TITLE
Add hook to annotate more CSS classes on events

### DIFF
--- a/src/ReactEventCalendar.js
+++ b/src/ReactEventCalendar.js
@@ -9,6 +9,7 @@ const propTypes = {
     year: React.PropTypes.number.isRequired,
     onEventClick: React.PropTypes.func,
     onEventMouseOver: React.PropTypes.func,
+    addEventClass: React.PropTypes.func
 };
 
 const defaultProps = {
@@ -188,7 +189,7 @@ class EventCalendar extends React.Component {
             'event-first-day': eventData.isFirstDay,
             'event-last-day': eventData.isLastDay,
             'event-has-label': showLabel,
-        });
+        }, this.props.addEventClass? this.props.addEventClass(eventData, day) : {});
 
         // Generate a dynamic identifier
         const UID = [day.month, day.day, index].join('_');


### PR DESCRIPTION
This allows us pass a prop `addEventClass` which can return an object or string (whatever `classnames()` accepts) with additional CSS classes to apply to the event.

This means we can for example colour-code events depending on some metadata. Better yet because it's done for each day, we can style different days of the same event differently if required.
