### PR TITLE
Fix bug whereby on first click, `ref` would be undefined

### DIFF
--- a/src/ReactEventCalendar.js
+++ b/src/ReactEventCalendar.js
@@ -199,9 +199,9 @@ class EventCalendar extends React.Component {
             <div className={eventClasses}
                 key={UID}
                 ref={(component) => this._eventTargets[UID] = component}
-                onClick={() => { this.props.onEventClick(this._eventTargets[UID], eventData, day); }}
-                onMouseOver={() => { this.props.onEventMouseOver(this._eventTargets[UID], eventData, day); }}
-                onMouseOut={() => { this.props.onEventMouseOut(this._eventTargets[UID], eventData, day); }}>
+                onClick={() => { this.props.onEventClick && this.props.onEventClick(this._eventTargets[UID], eventData, day); }}
+                onMouseOver={() => { this.props.onEventMouseOver && this.props.onEventMouseOver(this._eventTargets[UID], eventData, day); }}
+                onMouseOut={() => { this.props.onEventMouseOut && this.props.onEventMouseOut(this._eventTargets[UID], eventData, day); }}>
                 <div className="event-title">
                     {title}    
                 </div>

--- a/src/ReactEventCalendar.js
+++ b/src/ReactEventCalendar.js
@@ -199,9 +199,9 @@ class EventCalendar extends React.Component {
             <div className={eventClasses}
                 key={UID}
                 ref={(component) => this._eventTargets[UID] = component}
-                onClick={this.props.onEventClick.bind(null, this._eventTargets[UID], eventData, day)}
-                onMouseOver={this.props.onEventMouseOver.bind(null, this._eventTargets[UID], eventData, day)}
-                onMouseOut={this.props.onEventMouseOut.bind(null, this._eventTargets[UID], eventData, day)}>
+                onClick={() => { this.props.onEventClick(this._eventTargets[UID], eventData, day); }}
+                onMouseOver={() => { this.props.onEventMouseOver(this._eventTargets[UID], eventData, day); }}
+                onMouseOut={() => { this.props.onEventMouseOut(this._eventTargets[UID], eventData, day); }}>
                 <div className="event-title">
                     {title}    
                 </div>


### PR DESCRIPTION
Because of the way the `_eventTargets[UID]` lookup is only set when the component is first mounted, it seems that on the first click/mouseover/mouseout, the first parameter to the event handler would be undefined.

This change fixes this problem by deferring to a function that can use the closure data.
