### PR TITLE
Fix bug whereby events crossing year boundary could be hidden

### DIFF
--- a/src/ReactEventCalendar.js
+++ b/src/ReactEventCalendar.js
@@ -81,7 +81,11 @@ class EventCalendar extends React.Component {
         if (eventStartInView || eventEndInView) {
              // Asserts event's first or last day is visible in this month view
             eventMeta.isVisibleInView = true;
-        } else if (eventStart.month < this.props.month && eventEnd.month > this.props.month) {
+        } else if (
+            (eventStart.year < this.props.year) ||
+            (eventEnd.year > this.props.year) ||
+            (eventStart.year === this.props.year && eventStart.month < this.props.month && eventEnd.month > this.props.month)
+        ) {
             // Asserts at least part of month is
             eventMeta.isVisibleInView = true;
         }


### PR DESCRIPTION
Date maths is hard. :)

If you have an event that finishes in an earlier month in a later year, it could be hidden by the previous logic.

Feels like it should be possible to do this with moment().isBetween(), but it kind of gets a bit tricky because we don't check against a specific day.
