### PR TITLE
Fix bug whereby events crossing year boundary could be hidden

### DIFF
--- a/src/ReactEventCalendar.js
+++ b/src/ReactEventCalendar.js
@@ -81,7 +81,11 @@ class EventCalendar extends React.Component {
         if (eventStartInView || eventEndInView) {
              // Asserts event's first or last day is visible in this month view
             eventMeta.isVisibleInView = true;
-        } else if (eventStart.month < this.props.month && eventEnd.month > this.props.month) {
+        } else if (
+            (eventStart.year < this.props.year) ||
+            (eventEnd.year > this.props.year) ||
+            (eventStart.year === this.props.year && eventStart.month < this.props.month && eventEnd.month > this.props.month)
+        ) {
             // Asserts at least part of month is
             eventMeta.isVisibleInView = true;
         }

--- a/src/ReactEventCalendar.js
+++ b/src/ReactEventCalendar.js
@@ -82,9 +82,8 @@ class EventCalendar extends React.Component {
              // Asserts event's first or last day is visible in this month view
             eventMeta.isVisibleInView = true;
         } else if (
-            (eventStart.year < this.props.year) ||
-            (eventEnd.year > this.props.year) ||
-            (eventStart.year === this.props.year && eventStart.month < this.props.month && eventEnd.month > this.props.month)
+            (eventStart.year < this.props.year || (eventStart.year === this.props.year && eventStart.month < this.props.month)) &&
+            (eventEnd.year > this.props.year || (eventEnd.year === this.props.year && eventEnd.month > this.props.month))
         ) {
             // Asserts at least part of month is
             eventMeta.isVisibleInView = true;
@@ -154,10 +153,10 @@ class EventCalendar extends React.Component {
     getCalendarDayObject(date) {
         const dateArray = date.split('-');
         return {
-            year: dateArray[0],
+            year: parseInt(dateArray[0], 10),
             // Subtract 1 from month to allow for human declared months
-            month: dateArray[1] - 1,
-            day: dateArray[2],
+            month: parseInt(dateArray[1], 10) - 1,
+            day: parseInt(dateArray[2], 10),
         };
     }
 


### PR DESCRIPTION
The code only checked for month, not year, so an event spanning across the new year would potentially be hidden/shown when it shouldn't be.

Also, there's a problem whereby the splitting of the date string will result in some numbers being strings, so use parseInt() just in case (I was having a hard time with === compares!)
