### PR TITLE
Added onDayClick event

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ const events = [
 | year | int |   | (Required) Selected Year to display |
 | wrapTitle | boolean | true | Redisplay an event's title if it's duration wraps to the next week
 | maxEventSlots | int | 10 | Maximum number of events to display per calendar day 
+| onDayClick | func(target, day) |   | Callback for user click on any day (but not an event node) |
 | onEventClick | func(target, eventData, day) |   | Callback for user click on any event node |
 | onEventMouseOver | func(target, eventData, day) |   | Callback for user mouse over on any event node |
 | onEventMouseOut | func(target, eventData, day) |   | Callback for user mouse out on any event node |

--- a/demo/CalendarDemo.jsx
+++ b/demo/CalendarDemo.jsx
@@ -34,6 +34,7 @@ class CalendarDemo extends React.Component {
         this.handleEventClick = this.handleEventClick.bind(this);
         this.handleEventMouseOver = this.handleEventMouseOver.bind(this);
         this.handleEventMouseOut = this.handleEventMouseOut.bind(this);
+        this.handleDayClick = this.handleDayClick.bind(this);
         this.handleModalClose = this.handleModalClose.bind(this);
     }
 
@@ -59,16 +60,16 @@ class CalendarDemo extends React.Component {
         this.setState({
             showPopover: true,
             popoverTarget: () => ReactDOM.findDOMNode(target),
-            overlayTitle: eventData.title,
-            overlayContent: eventData.description,
+                overlayTitle: eventData.title,
+                overlayContent: eventData.description,
         });
     }
 
-     handleEventMouseOut(target, eventData, day) {
+    handleEventMouseOut(target, eventData, day) {
         this.setState({
             showPopover: false,
         });
-     }
+    }
 
     handleEventClick(target, eventData, day) {
         this.setState({
@@ -76,6 +77,23 @@ class CalendarDemo extends React.Component {
             showModal: true,
             overlayTitle: eventData.title,
             overlayContent: eventData.description,
+        });
+    }
+
+    handleDayClick(target, day) {
+        this.setState({
+            showPopover: false,
+            showModal: true,
+            overlayTitle: this.getMomentFromDay(day).format('Do of MMMM YYYY'),
+            overlayContent: 'User clicked day (but not event node).',
+        });
+    }
+
+    getMomentFromDay(day) {
+        return moment().set({
+            'year': day.year,
+            'month': (day.month + 0) % 12,
+            'date': day.day
         });
     }
 
@@ -89,13 +107,13 @@ class CalendarDemo extends React.Component {
         return [moment.months('MM', this.state.moment.month()), this.state.moment.year(), ].join(' ');
     }
 
-	render() {
+    render() {
 
         const styles = {
             position: 'relative',
         };
 
-		return (
+        return (
             <div style={styles}>
 
                 <Overlay
@@ -105,7 +123,7 @@ class CalendarDemo extends React.Component {
                     placement="top"
                     container={this}
                     target={this.state.popoverTarget}>
-                  <Popover id="event">{this.state.overlayTitle}</Popover>
+                    <Popover id="event">{this.state.overlayTitle}</Popover>
                 </Overlay>
 
                 <Modal show={this.state.showModal} onHide={this.handleModalClose}>
@@ -129,9 +147,9 @@ class CalendarDemo extends React.Component {
                                 <Button onClick={this.handleToday}>Today</Button>
                             </ButtonToolbar>
                         </Col>
-                         <Col xs={6}>
+                        <Col xs={6}>
                             <div className="pull-right h2">{this.getHumanDate()}</div>
-                         </Col>
+                        </Col>
                     </Row>
                     <br />
                     <Row>
@@ -143,15 +161,16 @@ class CalendarDemo extends React.Component {
                                 onEventClick={this.handleEventClick}
                                 onEventMouseOver={this.handleEventMouseOver}
                                 onEventMouseOut={this.handleEventMouseOut}
+                                onDayClick={this.handleDayClick}
                                 maxEventSlots={10}
-                                />
+                            />
                         </Col>
                     </Row>
                 </Grid> 
-            
+
             </div>
-		);
-	}
+        );
+    }
 }
 
 export default CalendarDemo;

--- a/src/components/CalendarDay.js
+++ b/src/components/CalendarDay.js
@@ -30,4 +30,8 @@ CalendarDay.propTypes = {
   onClick: React.PropTypes.func,
 };
 
+CalendarDay.defaultProps = {
+  onClick: () => {},
+}
+
 export default CalendarDay;

--- a/src/components/CalendarDay.js
+++ b/src/components/CalendarDay.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import classnames from 'classnames';
-import moment from 'moment';
 
 const CalendarDay = ({day, isToday, events, onClick}) => {
     const dayClasses = classnames({
@@ -12,7 +11,7 @@ const CalendarDay = ({day, isToday, events, onClick}) => {
 
     return (
       <div 
-        onClick = {onClick.bind(null, 'day', day)}
+        onClick={onClick.bind(null, 'day', day)}
         className={dayClasses}>
             <div className="inner-grid">
                 <div className="date">

--- a/src/components/CalendarDay.js
+++ b/src/components/CalendarDay.js
@@ -1,26 +1,28 @@
 import React from 'react';
 import classnames from 'classnames';
 
-const CalendarDay = ({day, isToday, events, onClick}) => {
+class CalendarDay extends React.Component {
+  render () {
     const dayClasses = classnames({
         'flexColumn': true,
         'day': true,
-        'inactive': day.siblingMonth,
-        'today': isToday,
+        'inactive': this.props.day.siblingMonth,
+        'today': this.props.isToday,
     });
 
     return (
       <div 
-        onClick={onClick.bind(null, 'day', day)}
+        onClick={this.props.onClick.bind(null, this, this.props.day)}
         className={dayClasses}>
             <div className="inner-grid">
                 <div className="date">
-                    {day.day}
+                    {this.props.day.day}
                 </div>
-                {events}
+                {this.props.events}
             </div>
         </div>
     );
+  }
 }
 
 CalendarDay.propTypes = {

--- a/src/components/CalendarDay.js
+++ b/src/components/CalendarDay.js
@@ -1,39 +1,40 @@
 import React from 'react';
 import classnames from 'classnames';
 
-class CalendarDay extends React.Component {
-  render () {
-    const dayClasses = classnames({
-        'flexColumn': true,
-        'day': true,
-        'inactive': this.props.day.siblingMonth,
-        'today': this.props.isToday,
-    });
+export default class CalendarDay extends React.Component {
+    render () {
+        const { day, isToday, events, onClick } = this.props;
+        const dayClasses = classnames({
+            'flexColumn': true,
+            'day': true,
+            'inactive': day.siblingMonth,
+            'today': isToday,
+        });
 
-    return (
-      <div 
-        onClick={this.props.onClick.bind(null, this, this.props.day)}
-        className={dayClasses}>
-            <div className="inner-grid">
-                <div className="date">
-                    {this.props.day.day}
+        return (
+            <div 
+                onClick={onClick.bind(null, this, day)}
+                className={dayClasses}>
+                <div className="inner-grid">
+                    <div className="date">
+                        {day.day}
+                    </div>
+                    {events}
                 </div>
-                {this.props.events}
             </div>
-        </div>
-    );
-  }
+        );
+    }
 }
 
 CalendarDay.propTypes = {
-  day: React.PropTypes.object.isRequired,
-  isToday: React.PropTypes.bool,
-  events: React.PropTypes.array,
-  onClick: React.PropTypes.func,
+    day: React.PropTypes.object.isRequired,
+    isToday: React.PropTypes.bool,
+    events: React.PropTypes.array,
+    onClick: React.PropTypes.func,
 };
 
 CalendarDay.defaultProps = {
-  onClick: () => {},
+    onClick: () => {},
 }
 
 export default CalendarDay;

--- a/src/components/CalendarDay.js
+++ b/src/components/CalendarDay.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import classnames from 'classnames';
+import moment from 'moment';
 
-const CalendarDay = ({day, isToday, events}) => {
+const CalendarDay = ({day, isToday, events, onClick}) => {
     const dayClasses = classnames({
         'flexColumn': true,
         'day': true,
@@ -10,7 +11,9 @@ const CalendarDay = ({day, isToday, events}) => {
     });
 
     return (
-        <div className={dayClasses}>
+      <div 
+        onClick = {onClick.bind(null, 'day', day)}
+        className={dayClasses}>
             <div className="inner-grid">
                 <div className="date">
                     {day.day}
@@ -25,6 +28,7 @@ CalendarDay.propTypes = {
   day: React.PropTypes.object.isRequired,
   isToday: React.PropTypes.bool,
   events: React.PropTypes.array,
+  onClick: React.PropTypes.func,
 };
 
 export default CalendarDay;

--- a/src/components/CalendarEvent.js
+++ b/src/components/CalendarEvent.js
@@ -25,7 +25,12 @@ class CalendarEvent extends React.Component {
 
     return (
             <div className={eventClasses}
-                 onClick={this.props.onClick.bind(...sharedArguments)}
+              onClick={
+                (e) => {
+                  this.props.onClick.bind(...sharedArguments)();
+                  e.stopPropagation();
+                }
+              }
                  onMouseOut={this.props.onMouseOut.bind(...sharedArguments)}
                  onMouseOver={this.props.onMouseOver.bind(...sharedArguments)}
             >

--- a/src/components/CalendarEvent.js
+++ b/src/components/CalendarEvent.js
@@ -4,59 +4,67 @@ import classnames from 'classnames';
 
 class CalendarEvent extends React.Component {
 
-  render() {
-    // Return a placeholder element if there is no event data 
-    if(!this.props.eventData) {
-        return <div className="event-slot"></div>;
+    constructor(props) {
+        super(props);
+
+        this.sharedArguments = [null, this, this.props.eventData, this.props.day];
+        // Bind methods
+        this.handleClick = this.handleClick.bind(this);
     }
 
-    const showLabel = this.props.eventData.isFirstDay || (this.props.day.weekDay === 0 && this.props.wrapTitle);
-    const title = showLabel ? this.props.eventData.title : '';
+    handleClick(e) {
+        this.props.onClick(...this.sharedArguments.slice(1));
+        e.stopPropagation();
+    }
 
-    const eventClasses = classnames({
-        'event-slot': true,
-        'event': true,
-        'event-first-day': this.props.eventData.isFirstDay,
-        'event-last-day': this.props.eventData.isLastDay,
-        'event-has-label': showLabel,
-    }, this.props.eventData.eventClasses);
+    render() {
+        // Return a placeholder element if there is no event data 
+        if(!this.props.eventData) {
+            return <div className="event-slot"></div>;
+        }
 
-    const sharedArguments = [null, this, this.props.eventData, this.props.day];
+        const showLabel = this.props.eventData.isFirstDay || (this.props.day.weekDay === 0 && this.props.wrapTitle);
+        const title = showLabel ? this.props.eventData.title : '';
 
-    return (
-      <div className={eventClasses}
-        onClick={e => {
-          const [ , ...args ] = sharedArguments;
-          this.props.onClick(...args);
-          e.stopPropagation();
-        }}
-        onMouseOut={this.props.onMouseOut.bind(...sharedArguments)}
-        onMouseOver={this.props.onMouseOver.bind(...sharedArguments)}
-      >
-        <div className="event-title">
-          {title}    
-        </div>
-      </div>
-    );
-}
+        const eventClasses = classnames({
+            'event-slot': true,
+            'event': true,
+            'event-first-day': this.props.eventData.isFirstDay,
+            'event-last-day': this.props.eventData.isLastDay,
+            'event-has-label': showLabel,
+        }, this.props.eventData.eventClasses);
+
+
+        return (
+            <div className={eventClasses}
+                onClick={this.handleClick}
+                onMouseOut={this.props.onMouseOut.bind(...this.sharedArguments)}
+                onMouseOver={this.props.onMouseOver.bind(...this.sharedArguments)}
+            >
+                <div className="event-title">
+                    {title}    
+                </div>
+            </div>
+        );
+    }
 }
 
 CalendarEvent.propTypes = {
-  day: React.PropTypes.object.isRequired,
-  eventData: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.bool,
-  ]),
-  onClick: React.PropTypes.func,
-  onMouseOut: React.PropTypes.func,
-  onMouseOver: React.PropTypes.func,
-  wrapTitle: React.PropTypes.bool,
+    day: React.PropTypes.object.isRequired,
+    eventData: React.PropTypes.oneOfType([
+        React.PropTypes.object,
+        React.PropTypes.bool,
+    ]),
+    onClick: React.PropTypes.func,
+    onMouseOut: React.PropTypes.func,
+    onMouseOver: React.PropTypes.func,
+    wrapTitle: React.PropTypes.bool,
 };
 
 CalendarEvent.defaultProps = {
-  onClick: () => {},
+    onClick: () => {},
     onMouseOut: () => {},
-      onMouseOver: () => {},
+    onMouseOver: () => {},
 }
 
 export default CalendarEvent;

--- a/src/components/CalendarEvent.js
+++ b/src/components/CalendarEvent.js
@@ -24,22 +24,21 @@ class CalendarEvent extends React.Component {
     const sharedArguments = [null, this, this.props.eventData, this.props.day];
 
     return (
-            <div className={eventClasses}
-              onClick={
-                (e) => {
-                  this.props.onClick.bind(...sharedArguments)();
-                  e.stopPropagation();
-                }
-              }
-                 onMouseOut={this.props.onMouseOut.bind(...sharedArguments)}
-                 onMouseOver={this.props.onMouseOver.bind(...sharedArguments)}
-            >
-                <div className="event-title">
-                    {title}    
-                </div>
+      <div className={eventClasses}
+        onClick={e => {
+          const [ , ...args ] = sharedArguments;
+          this.props.onClick(...args);
+          e.stopPropagation();
+        }}
+        onMouseOut={this.props.onMouseOut.bind(...sharedArguments)}
+        onMouseOver={this.props.onMouseOver.bind(...sharedArguments)}
+      >
+        <div className="event-title">
+          {title}    
         </div>
+      </div>
     );
-  }
+}
 }
 
 CalendarEvent.propTypes = {
@@ -56,8 +55,8 @@ CalendarEvent.propTypes = {
 
 CalendarEvent.defaultProps = {
   onClick: () => {},
-  onMouseOut: () => {},
-  onMouseOver: () => {},
+    onMouseOut: () => {},
+      onMouseOver: () => {},
 }
 
 export default CalendarEvent;

--- a/src/index.js
+++ b/src/index.js
@@ -197,7 +197,9 @@ class EventCalendar extends React.Component {
                     key={'day_'+this.getSerializedDay(day)}
                     day={day} 
                     events={events}
-                    isToday={isToday} />
+                    isToday={isToday} 
+                    onClick={this.props.onClick}
+                    />
                 );
         });
     }
@@ -222,6 +224,7 @@ EventCalendar.propTypes = {
     onEventMouseOver: React.PropTypes.func,
     wrapTitle: React.PropTypes.bool,
     year: React.PropTypes.number.isRequired,
+    onClick: React.PropTypes.func,
 
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ class EventCalendar extends React.Component {
                     day={day} 
                     events={events}
                     isToday={isToday} 
-                    onClick={this.props.onClick}
+                    onClick={this.props.onDayClick}
                     />
                 );
         });
@@ -222,9 +222,9 @@ EventCalendar.propTypes = {
     onEventClick: React.PropTypes.func,
     onEventMouseOut: React.PropTypes.func,
     onEventMouseOver: React.PropTypes.func,
+    onDayClick: React.PropTypes.func,
     wrapTitle: React.PropTypes.bool,
     year: React.PropTypes.number.isRequired,
-    onClick: React.PropTypes.func,
 
 };
 


### PR DESCRIPTION
**This is a WIP for #21.** 

I added an `onClick(target, day)` property to `EventCalendar` that is passed down to `CalendarDay`. It is called when a user clicks on any day in the calendar.
If the user clicks on an event directly, the `onClick` function is not called, as I added a stopPropagation for the `onEventClick` event in `CalendarEvent`.

**WIP**
I couldn't figure out an easy way to pass a meaningful `target` property to `onClick`. At the moment I am just passing the string `'day'`. I saw that in `CalendarEvent` you are passing `this`, but we cannot do that in `CalendarDay` as long as its a functional component. 
Please let me know how you would like this issue to be resolved. 

**Other**
In case you like this addition, I am happy to make the changes to README.md, before this is merged.
