### PR TITLE
Fix missing event data in handler callbacks

### DIFF
--- a/src/components/CalendarEvent.js
+++ b/src/components/CalendarEvent.js
@@ -11,6 +11,10 @@ class CalendarEvent extends React.Component {
         // Bind methods
         this.handleClick = this.handleClick.bind(this);
     }
+    
+    componentWillReceiveProps(nextProps) {
+      this.sharedArguments = [null, this, nextProps.eventData, nextProps.day];
+    }
 
     handleClick(e) {
         this.props.onClick(...this.sharedArguments.slice(1));


### PR DESCRIPTION
Fixes #24

There is currently a bug where event data will be missing when the (e.g. `onMouseOver`) callbacks trigger - I currently get `false` on occasion for the [`eventData` param in my callback](https://github.com/dptoot/react-event-calendar#properties).

I believe this is because `this.sharedArguments` is only computed and cached once, when the component is created, and never updated as the props change. So on each subsequent re-render, there is a chance the two will become out of sync.

This fixes it by updating `this.sharedArguments` each time the props update.

@calvinclaus @dptoot 
