### PR TITLE
Provide transipiled css

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gh-pages": "webpack",
     "gh-pages:deploy": "gh-pages -d gh-pages",
     "gh-pages:stats": "webpack --profile --json > stats.json",
-    "dist": "webpack --display-error-details",
+    "dist": "webpack --display-error-details && node-sass style.css dist/style.css",
     "dist:min": "webpack --display-error-details",
     "dist:modules": "babel ./src --out-dir ./dist-modules",
     "pretest": "npm run test:lint",

--- a/src/components/CalendarDay.js
+++ b/src/components/CalendarDay.js
@@ -36,5 +36,3 @@ CalendarDay.propTypes = {
 CalendarDay.defaultProps = {
     onClick: () => {},
 }
-
-export default CalendarDay;


### PR DESCRIPTION
This is helpful because it allows non-Sass users to more easily use the module.
